### PR TITLE
MVC 테스트 코드 수정

### DIFF
--- a/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboard.controller;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
@@ -106,11 +107,13 @@ public class DataRestTest {
 
         // When
         mvc.perform(get("/api/userAccounts")).andExpect(status().isNotFound());
-        mvc.perform(post("/api/userAccounts")).andExpect(status().isNotFound());
-        mvc.perform(put("/api/userAccounts")).andExpect(status().isNotFound());
-        mvc.perform(patch("/api/userAccounts"))
+        mvc.perform(post("/api/userAccounts").with(csrf()))
             .andExpect(status().isNotFound());
-        mvc.perform(delete("/api/userAccounts"))
+        mvc.perform(put("/api/userAccounts").with(csrf()))
+            .andExpect(status().isNotFound());
+        mvc.perform(patch("/api/userAccounts").with(csrf()))
+            .andExpect(status().isNotFound());
+        mvc.perform(delete("/api/userAccounts").with(csrf()))
             .andExpect(status().isNotFound());
         mvc.perform(head("/api/userAccounts")).andExpect(status().isNotFound());
     }


### PR DESCRIPTION
일부 테스트 코드에서 스프링 시큐리티 적용으로 인해 POST, PUT, PATCH, DELETE 등의 http 메소드로 요청을 보내면 csrf 토큰이 없어 403 에러가 리턴되는 상황이 발생하였다.  
이를 CSRF 토큰을 통해 요청하도록 수정하여 테스트코드가 스펙에 맞게 동작하도록 변경함.